### PR TITLE
To make it consistent

### DIFF
--- a/docs/create_validator.md
+++ b/docs/create_validator.md
@@ -11,7 +11,7 @@ Follow the prompts and supply the password, you will receive output;
 ```
 Your new key was generated
 
-Public address of the key:   0xAddress
+Public address of the key:   0xYourAddress
 Path of the secret key file:
 
 - You can share your public address with anyone. Others need it to interact with you.


### PR DESCRIPTION
While creating a wallet, the docs say that the output is `0xAddress`. Further down in the docs, `0xYourAddress` is used. This makes it confusing. 
The idea of this PR is to make the wording consistent.